### PR TITLE
Controller and Publisher Refactor

### DIFF
--- a/examples/framecount.py
+++ b/examples/framecount.py
@@ -46,7 +46,7 @@ class TestController(object):
         # need to keep track of how much time is left.
         # Alternatively could keep the time to run and accumulate.
 
-        scene.subscribe(Tick, id(self), self.tick)
+        scene.subscribe(Tick, self.tick)
         # subscribe to Tick events with the scene.
 
     def tick(self, event):
@@ -83,7 +83,7 @@ class TestView(object):
         # A countdown to control render speed.
         self.count = 0
         # A simple accumulator to count frames.
-        scene.subscribe(Tick, id(self), self.tick)
+        scene.subscribe(Tick, self.tick)
         # Subscribe to the scene.
 
     def tick(self, event):

--- a/ppb/controller.py
+++ b/ppb/controller.py
@@ -1,0 +1,42 @@
+import ppb.engine as engine
+from ppb.event import Tick
+
+
+class Controller(object):
+    """
+    A basic controller interface.
+
+    Requires a hardware middleware that provides access to a keys, mouse, and
+    events function.
+    """
+
+    def __init__(self, scene, hardware):
+        """
+        Attributes: keys: A dictionary of the hardware keys
+                    mouse: An object definition of a mouse
+
+        :param scene: Publisher
+        :param hardware: An object with a keys, mouse and events functions.
+                         keys should return a dictionary of the key state.
+                         mouse should return an object representation of the mouse.
+                         events should return hardware events translated into ppb events.
+        :return:
+        """
+        scene.subscribe(Tick, id(self), self.tick)
+        self.keys = None
+        self.mouse = None
+        self.hardware = hardware
+
+    def tick(self, event):
+        """
+        Update the key and mouse state. Push hardware events to the queue.
+
+        :param event: ppb.Event
+        :return:
+        """
+
+        self.keys = self.hardware.keys()
+        self.mouse = self.hardware.mouse()
+        events = self.hardware.events()
+        for e in events:
+            engine.message(e)

--- a/ppb/engine.py
+++ b/ppb/engine.py
@@ -72,11 +72,11 @@ def push(e):
         scene = e.scene
     except AttributeError:
         scene = e
-    scene.subscribe(event.Tick, "engine", tick)
-    scene.subscribe(event.Quit, "engine", game_quit)
-    scene.subscribe(event.PushScene, "engine", push)
-    scene.subscribe(event.PopScene, "engine", pop)
-    scene.subscribe(event.ReplaceScene, "engine", replace)
+    scene.subscribe(event.Tick, tick)
+    scene.subscribe(event.Quit, game_quit)
+    scene.subscribe(event.PushScene, push)
+    scene.subscribe(event.PopScene, pop)
+    scene.subscribe(event.ReplaceScene, replace)
     scenes.append(scene)
 
 

--- a/ppb/event.py
+++ b/ppb/event.py
@@ -51,3 +51,39 @@ class ReplaceScene(PushScene):
     """
 
     pass
+
+
+class Key(Event):
+    """
+    Events related to keys.
+    """
+
+    def __init__(self, identifier, name):
+        """
+
+        :param identifier: Key ID
+        :param name: A human readable keyname.
+        :return:
+        """
+        super().__init__()
+        self.key = identifier
+        self.name = name
+
+    def __repr__(self):
+        return "{}({}, {})".format(self.__class__.__name__, self.key, self.name)
+
+
+class KeyUp(Key):
+    pass
+
+
+class KeyDown(Key):
+    pass
+
+
+class MouseButtonUp(Key):
+    pass
+
+
+class MouseButtonDown(Key):
+    pass


### PR DESCRIPTION
The controller is built to be generic, requiring a middleware
to access the hardware. Added to events are a series of events
to use for building middleware.

Publishers refactors to use sets instead of dictionaries,
removing the need for an "identity" to track subscribers. The
callback functions operate as the unique identifier.