### PR TITLE
Emitter Class, Publisher Fix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,16 @@
+# TODO List
+
+A project wide todo list for keeping note of changes that need to be made to
+other parts of the project. Kept here to be available in the project and not 
+tucked into working code.
+
+## Priority
+
+Tasks that need to happen ASAP. Generally broken systems.
+
+## Other
+
+General tasks.
+
+* Make a scene class that inherits from Publisher and includes a view. Intended 
+to clean up parameters in the project.

--- a/examples/zombies/run_game.py
+++ b/examples/zombies/run_game.py
@@ -3,11 +3,10 @@ import logging
 import pygame
 from pygame.surface import Surface
 
-from ppb import engine
-from ppb.controller import Controller
+from ppb import engine, Controller
 from ppb.ext import hw_pygame as hardware
 from ppb.utilities import Publisher
-from ppb.event import Quit
+from ppb.event import Quit, Tick
 import zombies.objects
 
 
@@ -30,9 +29,12 @@ def main():
     player = zombies.objects.Player((300, 200), scene, controller, controls, image, view)
     image = pygame.Surface((4, 4))
     image.fill((255, 255, 255))
-    zombies.objects.Particle(scene=scene, pos=(0, 0), view=view,
-                             velocity=(5, 5), image=image, life_time=5)
+    zombies.objects.Emitter(zombies.objects.Particle, image, (0, 0), scene, view)
+    # scene.subscribe(Tick, raise_quit)
     engine.run(scene)
+
+def raise_quit(_):
+    engine.message(Quit())
 
 if __name__ == "__main__":
     main()

--- a/examples/zombies/zombies/objects.py
+++ b/examples/zombies/zombies/objects.py
@@ -6,7 +6,7 @@ Name not final.
 
 import logging
 
-from ppb.event import Tick
+from ppb.event import Tick, MouseButtonDown
 from ppb.ext.hw_pygame import Sprite
 from ppb.vmath import Vector2 as Vector
 
@@ -29,7 +29,6 @@ class Mob(object):
 class Renderable(Mob):
 
     def __init__(self, pos, scene, image=None, view=None, *args, **kwargs):
-        print kwargs
         super(Renderable, self).__init__(pos=pos, scene=scene, image=image,
                                          view=view, *args, **kwargs)
         self.sprite = Sprite(image, self)
@@ -101,7 +100,6 @@ class Particle(Renderable):
                        life_time: Amount of time to persist
         :return:
         """
-        print image
         super(Particle, self).__init__(pos=pos, scene=scene,
                                        image=image, view=view, *args, **kwargs)
         self.life_time = kwargs.get('life_time', float('inf'))
@@ -111,3 +109,27 @@ class Particle(Renderable):
         if self.life_time <= 0.0:
             self.kill()
         super(Particle, self).tick(event)
+
+
+class Emitter(object):
+
+    def __init__(self, particle, image, pos, scene, view):
+        self.active = False
+        self.particle = particle
+        self.pos = Vector(*pos)
+        self.scene = scene
+        self.scene.subscribe(Tick, self.tick)
+        self.scene.subscribe(MouseButtonDown, self.emit)
+        self.particle_image = image
+        self.view = view
+
+    def emit(self, _):
+        self.active = True
+
+    def tick(self, tick):
+        if self.active:
+            self.particle(self.pos, self.scene, image=self.particle_image,
+                          view=self.view, velocity=self.particle_velocity())
+
+    def particle_velocity(self):
+        return Vector(60, 60)

--- a/ppb/__init__.py
+++ b/ppb/__init__.py
@@ -1,0 +1,1 @@
+from controller import Controller

--- a/ppb/controller.py
+++ b/ppb/controller.py
@@ -20,8 +20,10 @@ class Controller(object):
         :param scene: Publisher
         :param hardware: An object with a keys, mouse and events functions.
                          keys should return a dictionary of the key state.
-                         mouse should return an object representation of the mouse.
-                         events should return hardware events translated into ppb events.
+                         mouse should return an object representation of the
+                             mouse.
+                         events should return hardware events translated into
+                             ppb events.
         :return:
         """
         scene.subscribe(Tick, self.tick)
@@ -36,7 +38,8 @@ class Controller(object):
         :param event: ppb.Event
         :return:
         """
-        # Due to a pygame problem, must get the events before key and button states.
+        # Due to a pygame problem, must get the events before key and button
+        # states.
         events = self.hardware.events()
         engine.message(events)
         self.keys = self.hardware.keys()

--- a/ppb/ext/hw_pygame.py
+++ b/ppb/ext/hw_pygame.py
@@ -110,10 +110,8 @@ class View(ppb.view.View):
         self.background = background
 
     def render(self):
-        logging.debug("Sprites: {}".format(self.layers.sprites()))
         self.layers.update()
         updates = self.layers.draw(display, self.background)
-        logging.debug("Updates: {}".format(updates))
         pygame.display.update(updates)
 
     def add(self, sprite, layer=0):
@@ -141,9 +139,7 @@ class Sprite(DirtySprite):
 
     def update(self):
         offset_position = self.model.pos - self.offset
-        logging.debug("offset position: {}".format(offset_position))
         new_pos = tuple(int(x) for x in offset_position)
-        logging.debug("New pos: {}, Topleft: {}".format(new_pos, self.rect.topleft))
         if new_pos != self.rect.topleft:
             self.rect.topleft = new_pos
             self.dirty = 1


### PR DESCRIPTION
Emitter class has an activate callback that listens for an
event and sets to active state. Also listens for a tick to
activate an emit function.

Publish would break if adding a callback in the middle of a
publishing loop. Added a subscribe_requests queue, and an add
function that is called before publishing. API has not changed.

Removed various logging and unnecessary documentation.