### PR TITLE
Refactor GameObjects

### DIFF
--- a/examples/zombies/run_game.py
+++ b/examples/zombies/run_game.py
@@ -16,7 +16,7 @@ from ppb.vmath import Vector2 as Vector
 publisher = Publisher()
 
 
-class Player(models.GameObject, models.Controllable, models.Renderable, models.Collider):
+class Player(models.GameObject, models.Mobile, models.Renderable, models.Collider):
     pass
 
 
@@ -24,7 +24,7 @@ class Bullet(models.GameObject, models.Mobile, models.Renderable, models.Collide
     pass
 
 
-class Target(models.GameObject, models.Controllable, models.Renderable, models.Collider):
+class Target(models.GameObject, models.Renderable, models.Collider):
     pass
 
 
@@ -37,7 +37,7 @@ def hit(self, collision):
         else:
             other = item
     if is_hit:
-        if isinstance(other, Bullet):
+        if isinstance(other, Bullet) or isinstance(other, Target):
             self.kill()
 
 
@@ -59,7 +59,7 @@ def main(_):
     publisher.subscribe(ObjectDestroyed, unsubscribe)
     controller = Controller(publisher, hardware)
     view = hardware.View(publisher, hardware.display, 30, hardware, Surface((600, 400)))
-    Physics(scene=publisher)
+    Physics()
 
     image = pygame.Surface((20, 20))
     image.fill((128, 65, 40))
@@ -73,7 +73,8 @@ def main(_):
     bullet_params = {"image": sprite_image,
                      "image_size": 4,
                      "hardware": hardware,
-                     "view": view}
+                     "view": view,
+                     "behaviors": [(Collision, hit)]}
     controls = [(Tick, control_move(controller, **controls)),
                 (MouseButtonDown, emit_object(Bullet, bullet_params, 1, 120))]
     Player(view=view,
@@ -81,7 +82,7 @@ def main(_):
            image_size=20,
            hardware=hardware,
            pos=Vector(300, 200),
-           commands=controls,
+           behaviors=controls,
            radius=10)
     target_image = pygame.Surface((20, 20))
     target_image.fill((0, 255, 0))
@@ -93,7 +94,7 @@ def main(_):
                hardware=hardware,
                pos=Vector(step * (x + 1), 50),
                radius=10,
-               commands=[(Collision, hit)])
+               behaviors=[(Collision, hit)])
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)

--- a/ppb/components/models.py
+++ b/ppb/components/models.py
@@ -7,37 +7,57 @@ from ppb.vmath import Vector2 as Vec
 Command = namedtuple("Command", ["event", "callback"])
 
 
-class Model(object):
-
-    def __init__(self, pos=Vec(0, 0), **kwargs):
-        self.pos = pos
-        self.commands = []
-
-    def kill(self):
-        engine.message(ObjectDestroyed(self, self.commands))
-
-
-class GameObject(Model):
+class Mixable(object):
 
     def __init__(self, *args, **kwargs):
-        super(GameObject, self).__init__(*args, **kwargs)
-        engine.message(ObjectCreated(self, self.commands))
+        pass
 
 
-class Mobile(Model):
+class GameObject(Mixable):
+
+    def __init__(self, pos=Vec(0, 0), behaviors=None, *args, **kwargs):
+        self.pos = pos
+        self.behaviors = []
+        if behaviors is not None:
+            for event, func in behaviors:
+                self.behaviors.append((event, self.bind(func)))
+        super(GameObject, self).__init__(pos=pos,
+                                         behaviors=behaviors,
+                                         *args,
+                                         **kwargs)
+        engine.message(ObjectCreated(self, self.behaviors))
+
+    def kill(self):
+        engine.message(ObjectDestroyed(self, self.behaviors))
+
+    def bind(self, function):
+        """
+        Bind a callback to Controllable.
+
+        :param function: Must be a function with a signature of
+                         function(self, event)
+        """
+
+        def callback(event):
+            return function(self, event)
+
+        return callback
+
+
+class Mobile(Mixable):
 
     def __init__(self, velocity=Vec(0, 0), *args, **kwargs):
         super(Mobile, self).__init__(velocity=velocity,
                                      *args,
                                      **kwargs)
         self.velocity = velocity
-        self.commands.append((Tick, self.tick))
+        self.behaviors.append((Tick, self.simulate))
 
-    def tick(self, tick):
+    def simulate(self, tick):
         self.pos += self.velocity * tick.sec
 
 
-class Renderable(Model):
+class Renderable(Mixable):
 
     def __init__(self, image=None, view=None, image_size=0, hardware=None, *args, **kwargs):
         super(Renderable, self).__init__(image=image,
@@ -53,50 +73,7 @@ class Renderable(Model):
         engine.message(Message(self, None, {"command": "kill"}))
 
 
-class Controllable(Mobile):
-
-    def __init__(self, commands=None, *args, **kwargs):
-        super(Controllable, self).__init__(commands=commands,
-                                           *args,
-                                           **kwargs)
-        if commands is not None:
-            for command in commands:
-                self.register_command(command)
-
-    def register_command(self, command):
-        """
-        Register controls to events.
-
-        To respond the state of the keyboard or mouse each loop, subscribe your
-        function to Tick.
-
-        To respond to the instance of pressing a mouse button or key subscribe
-        to MouseButtonDown or KeyDown.
-
-        You can also respond to any other event.
-
-        :param scene: Publisher
-        :param command: iterable of length 2
-                        The first element should be an Event class.
-                        The second element should be a function of the
-                        signature func(self, event) and return None.
-        """
-        command = Command(command[0], self.bind(command[1]))
-        self.commands.append(command)
-
-    def bind(self, function):
-        """
-        Bind a callback to Controllable.
-
-        :param function: Must be a function with a signature of
-                         function(self, event)
-        """
-        def callback(event):
-            return function(self, event)
-        return callback
-
-
-class Collider(Model):
+class Collider(Mixable):
 
     def __init__(self, radius=0, *args, **kwargs):
         super(Collider, self).__init__(radius=radius, *args, **kwargs)

--- a/ppb/components/view.py
+++ b/ppb/components/view.py
@@ -2,6 +2,7 @@ from ppb.event import Tick, Quit, ObjectDestroyed
 from ppb.vmath import Vector2 as Vector
 from ppb import engine
 
+
 class View(object):
 
     def __init__(self, scene, display, fps, hardware):


### PR DESCRIPTION
General use hasn't changed, but universal behaviors are pulled
into a single GameObject, with a call to mixins inits in the
middle of the initialization process.

A mixin should call super first then set up new members and add
new behaviors to self.behaviors.