### PR TITLE
Extracted View from Renderable and Minor Refactors

### DIFF
--- a/examples/zombies/run_game.py
+++ b/examples/zombies/run_game.py
@@ -6,7 +6,7 @@ from pygame.surface import Surface
 from ppb import engine
 from ppb.ext import hw_pygame as hardware
 from ppb.utilities import Publisher
-from ppb.event import Start, Quit, Tick, MouseButtonDown, ObjectCreated, ObjectDestroyed, Collision
+from ppb.event import Quit, Tick, MouseButtonDown, ObjectCreated, ObjectDestroyed, Collision
 from ppb.components import Controller, models
 from ppb.components.controls import control_move, emit_object
 from ppb.physics import Physics
@@ -51,14 +51,14 @@ def unsubscribe(event):
         publisher.unsubscribe(*command)
 
 
-def main(_):
+def main():
+    logging.basicConfig(level=logging.DEBUG)
     hardware.init((600, 400), "Zombies!")
-
     publisher.subscribe(Quit, hardware.quit)
     publisher.subscribe(ObjectCreated, subscribe)
     publisher.subscribe(ObjectDestroyed, unsubscribe)
     controller = Controller(publisher, hardware)
-    view = hardware.View(publisher, hardware.display, 30, hardware, Surface((600, 400)))
+    hardware.View(publisher, hardware.display, 30, hardware, Surface((600, 400)))
     Physics()
 
     image = pygame.Surface((20, 20))
@@ -73,12 +73,10 @@ def main(_):
     bullet_params = {"image": sprite_image,
                      "image_size": 4,
                      "hardware": hardware,
-                     "view": view,
                      "behaviors": [(Collision, hit)]}
     controls = [(Tick, control_move(controller, **controls)),
                 (MouseButtonDown, emit_object(Bullet, bullet_params, 1, 120))]
-    Player(view=view,
-           image=image,
+    Player(image=image,
            image_size=20,
            hardware=hardware,
            pos=Vector(300, 200),
@@ -88,15 +86,13 @@ def main(_):
     target_image.fill((0, 255, 0))
     step = 600 / 6
     for x in range(5):
-        Target(view=view,
-               image=target_image,
+        Target(image=target_image,
                image_size=20,
                hardware=hardware,
                pos=Vector(step * (x + 1), 50),
                radius=10,
                behaviors=[(Collision, hit)])
+    engine.run(publisher)
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
-    publisher.subscribe(Start, main)
-    engine.run(publisher)
+    main()

--- a/ppb/components/controls.py
+++ b/ppb/components/controls.py
@@ -1,7 +1,7 @@
 import logging
 
 import ppb.engine as engine
-from ppb.event import Tick
+from ppb.event import Tick, ObjectCreated
 from ppb.vmath import Vector2 as Vec
 
 
@@ -27,10 +27,10 @@ class Controller(object):
                              ppb events.
         :return:
         """
-        scene.subscribe(Tick, self.tick)
         self.keys = hardware.keys()
         self.mouse = hardware.mouse()
         self.hardware = hardware
+        engine.message(ObjectCreated(self, ((Tick, self.tick),)))
 
     def __getitem__(self, item):
         if item in ['key', 'keys']:

--- a/ppb/components/models.py
+++ b/ppb/components/models.py
@@ -59,18 +59,14 @@ class Mobile(Mixable):
 
 class Renderable(Mixable):
 
-    def __init__(self, image=None, view=None, image_size=0, hardware=None, *args, **kwargs):
+    def __init__(self, image=None, view=None, image_size=0, *args, **kwargs):
         super(Renderable, self).__init__(image=image,
                                          view=view,
                                          image_size=image_size,
                                          *args,
                                          **kwargs)
-
-        view.add(hardware.Sprite(image, self, size=image_size))
-
-    def kill(self):
-        super(Renderable, self).kill()
-        engine.message(Message(self, None, {"command": "kill"}))
+        self.image = image
+        self.image_size = image_size
 
 
 class Collider(Mixable):

--- a/ppb/ext/hw_pygame.py
+++ b/ppb/ext/hw_pygame.py
@@ -8,6 +8,7 @@ from pygame.sprite import DirtySprite
 import ppb.components.view
 from ppb.event import KeyDown, KeyUp, MouseButtonDown, MouseButtonUp, Quit
 from ppb.vmath import Vector2 as Vector
+from ppb.components.models import Renderable
 
 
 display = None
@@ -122,6 +123,11 @@ class View(ppb.components.view.View):
     def change_layer(self, sprite, layer):
         self.layers.change_layer(sprite, layer)
 
+    def object_created(self, obj):
+        obj = obj.obj
+        if isinstance(obj, Renderable):
+            self.add(Sprite(obj))
+
     @property
     def sprites(self):
         return self.layers.sprites()
@@ -129,10 +135,10 @@ class View(ppb.components.view.View):
 
 class Sprite(DirtySprite, ppb.components.view.Sprite):
 
-    def __init__(self, image, model, *groups, **kwargs):
+    def __init__(self, model, *groups):
         super(Sprite, self).__init__(*groups)
-        self.image = image
-        self.rect = image.get_rect()
+        self.image = model.image
+        self.rect = self.image.get_rect()
         x_offset = self.rect.width / 2
         y_offset = self.rect.height / 2
         self.offset = Vector(x_offset, y_offset)


### PR DESCRIPTION
View listens for object creation and instantiates Sprites as
needed.

Refactored core engine to push a Tick event when the queue is
empty instead of listening to a Tick to raise a Tick.

Now the engine doesn't need to know that the scene has a subscribe
function just a publish function.